### PR TITLE
2D Player Respawn, Falling Scrolls, Enemies

### DIFF
--- a/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/PlayerStats.cs
+++ b/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/PlayerStats.cs
@@ -5,6 +5,8 @@ using UnityEngine.SceneManagement;
 
 public class PlayerStats : MonoBehaviour
 {
+    GameManager gameManager;
+
     [SerializeField] private Transform attackPoint;
     [SerializeField] private LayerMask enemyLayers;
 
@@ -30,6 +32,8 @@ public class PlayerStats : MonoBehaviour
 
     public PlayerAttach attachScript;
     // Start is called before the first frame update
+
+    Vector2 spawnPoint = Vector2.zero;
     void Awake()
     {        
         sr = GetComponent<SpriteRenderer>();
@@ -46,6 +50,14 @@ public class PlayerStats : MonoBehaviour
             print("Can't find huic's player stats so");
         }
     }//end on awake
+
+    private void Start()
+    {
+        spawnPoint = transform.position;
+        if (GameManager.instance != null) gameManager = GameManager.instance;
+        else Debug.LogWarning("GameManager Missing");
+
+    }
 
     // Update is called once per frame
     void Update()
@@ -119,19 +131,14 @@ public class PlayerStats : MonoBehaviour
             if(huic != null)
                 huic.PlayerCurrHealth = ps.CurrHealth;
 
-            if (GameManager.instance != null)
-            {
-                GameManager.instance.gameData.health = ps.CurrHealth;
-            }
-            print("Player Health: " + ps.CurrHealth.ToString() + " UI Health: " + huic.PlayerCurrHealth.ToString() + " GameManager Health: " + GameManager.instance.gameData.health.ToString());
+            gameManager.gameData.health = ps.CurrHealth;
+
             if (ps.CurrHealth <= 0)
             {
-                print("Died with <0 health");
                 Die();
             }
         }
-
-    }//end take damage
+    }
 
     public void Heal(int heal, bool potion) 
     {
@@ -152,73 +159,29 @@ public class PlayerStats : MonoBehaviour
                 huic.PlayerCurrHealth = ps.CurrHealth;
         }
 
-        if (GameManager.instance != null) 
-        {
-            GameManager.instance.gameData.health = ps.CurrHealth;
-        }
-    }//end heal
+        gameManager.gameData.health = ps.CurrHealth;
+    }
 
     private void Die()
     {
         if (ps.CurrHealth <= 0)
         {
-            print("Dead");
             anim.SetBool("IsDead", true);
-            GetComponent<Collider2D>().enabled = false;
-            GetComponent<Rigidbody2D>().simulated = false;
-            GetComponent<KnockBackFeedback>().enabled = false;
             GetComponent<PlayerController>().enabled = false;
-            //this.enabled = false;
-
-            //ps.CurrHealth = ps.MaxHealth;
-            if (attachScript != null && attachScript.localGameManager != null)
-            {
-                if (!respawning)
-                    StartCoroutine(Respawn());
-            }
-            else
-            {
-                SceneManager.LoadScene(SceneManager.GetActiveScene().name);
-            }
+            StartCoroutine(Respawn());
         }
     }
-
-   /*  void OnDrawGizmosSelected()
-    {
-        if (attackPoint == null)
-            return;
-
-        Gizmos.DrawWireSphere(attackPoint.position, ps.AttackRange/2);
-        Vector3 heightPoint = new Vector3 (attackPoint.position.x, attackPoint.position.y + ps.AttackHeight/2, attackPoint.position.z);
-        Gizmos.DrawWireSphere(heightPoint, ps.AttackRange/2);
-        heightPoint = new Vector3 (attackPoint.position.x, attackPoint.position.y - ps.AttackHeight/2, attackPoint.position.z);
-        Gizmos.DrawWireSphere(heightPoint, ps.AttackRange/2);
-    } */
-
     public void PlaySwordSwing()
     {
         aud.Play();
     }
-
     public IEnumerator Respawn() 
     {
-        respawning = true;
         yield return new WaitForSeconds(2f);
         print("Respawn");
-        if(attachScript.localGameManager != null) 
-        {
-            transform.position = attachScript.localGameManager.activePlayerSpawner.spawnPoints[0].position;
-        }
-        GetComponent<Collider2D>().enabled = true;
-        GetComponent<Rigidbody2D>().simulated = true;
-        GetComponent<KnockBackFeedback>().enabled = true;
+        transform.position = spawnPoint;
+        Heal((int)huic.PlayerMaxHealth, false);
         GetComponent<PlayerController>().enabled = true;
-        ps.CurrHealth = ps.MaxHealth;
-
-        if (huic != null)
-            huic.PlayerCurrHealth = ps.CurrHealth;
         anim.SetBool("IsDead", false);
-        respawning = false;
-    }
-    
+    }    
 }

--- a/Mythology Mayhem/Assets/2D Assets/Greek/Enemies/Mouse 2D/Mouse/FallingScrollBehavior.cs
+++ b/Mythology Mayhem/Assets/2D Assets/Greek/Enemies/Mouse 2D/Mouse/FallingScrollBehavior.cs
@@ -1,30 +1,14 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class FallingScrollBehavior : MonoBehaviour
 {
-    float countdown;
-    int damage;
-    // Start is called before the first frame update
-    void Start()
-    {
-        countdown = 3f;
-        damage = 2;
-    }//end start
+    [SerializeField] float countdown = 3;
+    [SerializeField] int damage = 2;
 
-    // Update is called once per frame
-    void Update()
-    {        
-        if(countdown <= 0) {
-            Destroy(this.gameObject);
-        } else {
-            countdown -= 1 * Time.deltaTime;
-        }
-    }//end update
-    
     private void OnTriggerEnter2D(Collider2D other) 
     {
+        if (other.gameObject.name == "ScrollCollider") Destroy(this.gameObject);
+
         if (other.gameObject.layer == 3)
         {
             other.gameObject.GetComponent<PlayerStats>().TakeDamage(damage);

--- a/Mythology Mayhem/Assets/Global Assets/Scenes/2D Scenes/Greek 2D/GreekLibrary_2D.unity
+++ b/Mythology Mayhem/Assets/Global Assets/Scenes/2D Scenes/Greek 2D/GreekLibrary_2D.unity
@@ -4339,6 +4339,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1575714034}
+  - {fileID: 2065485420}
   m_Father: {fileID: 1812523066}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9899,6 +9900,64 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 450319774758561872, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
   m_PrefabInstance: {fileID: 2057221954}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2065485419
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2065485420}
+  - component: {fileID: 2065485421}
+  m_Layer: 0
+  m_Name: ScrollCollider
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2065485420
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2065485419}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -2.93, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 722544658}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &2065485421
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2065485419}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -50.858597, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 55.63504, y: 1}
+  m_EdgeRadius: 0.2
 --- !u!1 &2099338767
 GameObject:
   m_ObjectHideFlags: 0

--- a/Mythology Mayhem/Assets/Global Assets/Scripts/Enemy/Enemy.cs
+++ b/Mythology Mayhem/Assets/Global Assets/Scripts/Enemy/Enemy.cs
@@ -3,6 +3,7 @@ using UnityEngine.Events;
 using UnityEngine;
 using System;
 using UnityEngine.AI;
+using System.Collections.Generic;
 
 [RequireComponent(typeof(Health))]
 [RequireComponent(typeof(Animator))]
@@ -78,19 +79,16 @@ public class Enemy : MythologyMayhem
         currentStatePosition = StatePosition.Entry;
         StartCoroutine(SwitchStates(currentState,0));
 
-        /*
-        GameObject tempLocalManager = GameObject.FindGameObjectWithTag("LocalGameManager");
+        _localGameManager = transform.root.GetComponent<LocalGameManager>();
 
-        if (tempLocalManager != null)
+        foreach (LocalGameManager lgm in GameObject.FindObjectsOfType<LocalGameManager>())
         {
-            _localGameManager =  tempLocalManager.GetComponent<LocalGameManager>();
+            if (lgm.inScene.ToString() == gameObject.scene.name) _localGameManager = lgm;
         }
-        */
-        
-    }//end Start
+    }
 
     void Update()
-    { 
+    {
         //set reference to player if in a scene using the StartScene feature
 
         if(_localGameManager != null && player == null)

--- a/Mythology Mayhem/Assets/Global Assets/Scripts/Enemy/Mouse2D.cs
+++ b/Mythology Mayhem/Assets/Global Assets/Scripts/Enemy/Mouse2D.cs
@@ -25,19 +25,9 @@ public class Mouse2D : MonoBehaviour
     [SerializeField] float countdown = 4f;
     [SerializeField] GameObject fallingScroll;
 
-    // Start is called before the first frame update
     void Start()
     {
         enemy = gameObject.GetComponent<Enemy>();
-        //playerCollider = enemy.player.GetComponent<BoxCollider2D>();
-    }
-
-    void Update()
-    {
-        if (enemy == null)
-        {
-            enemy = gameObject.GetComponent<Enemy>();
-        }
     }
 
     public void Idle()
@@ -144,7 +134,7 @@ public class Mouse2D : MonoBehaviour
             {
                 countdown = Random.Range(3, countdown);
                 //spawn fallingscroll prefab
-                Instantiate(fallingScroll, transform.position, Quaternion.identity);
+                if (GameManager.instance.currentLocalManager == enemy._localGameManager) Instantiate(fallingScroll, transform.position, Quaternion.identity);
             }
             else
             {


### PR DESCRIPTION
The 2D player now respawns similarly to the 3D player. Removed unnecessary update code. I added a collider to the Greek Library 2D scene for the falling scrolls. The falling scrolls no longer run a timer on update. They now check on trigger enter for the collider and are destroyed at this time. I fixed an issue with the enemy scripts not getting the local game manager on start. The 2D mouse will no longer drop scrolls if the player is not in its scene.