### PR TITLE
Greek Labyrinth

### DIFF
--- a/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/TwoDBow.cs
+++ b/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/TwoDBow.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class TwoDBow : MonoBehaviour
 {
-
+    GameManager gameManager;
     public bool pickUpAllowed = false;
     public bool pickedUp = false;
 
@@ -14,8 +14,15 @@ public class TwoDBow : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        puzzleManager = FindObjectOfType<PedastalsPuzzleManager>();
-        puzzleManager.itemBow = this.gameObject;
+        if (GameManager.instance != null) gameManager = GameManager.instance;
+        else Debug.LogWarning("GameManager Missing.");
+
+        if (FindObjectOfType<PedastalsPuzzleManager>() != null)
+        {
+            puzzleManager = FindObjectOfType<PedastalsPuzzleManager>();
+            puzzleManager.itemBow = this.gameObject;
+        }
+        else Debug.LogWarning("PedastalsPuzzleManager Missing.");
 
         if (puzzleManager.fishDone && puzzleManager.appleDone && puzzleManager.torchDone && puzzleManager.airDone && !puzzleManager.bowCollected)
         {
@@ -36,19 +43,22 @@ public class TwoDBow : MonoBehaviour
             PickUp();
         }
     }
-
-    private void OnTriggerEnter2D(Collider2D other) 
+    private void OnTriggerEnter2D(Collider2D other)
     {
-        if(other.gameObject.tag == "Player")
+        if (other.gameObject.tag == "Player")
         {
+            gameManager.Popup("Press E to Pick up", true);
+
             pickUpAllowed = true;
         }
     }
 
-    private void OnTriggerExit2D(Collider2D other) 
+    private void OnTriggerExit2D(Collider2D other)
     {
-        if(other.gameObject.tag == "Player")
+        if (other.gameObject.tag == "Player")
         {
+            gameManager.Popup("Press E to Pick up", false);
+
             pickUpAllowed = false;
         }
     }
@@ -57,7 +67,9 @@ public class TwoDBow : MonoBehaviour
     {
         pickedUp = true;
 
-        if(puzzleManager != null)
+        gameManager.gameData.collectedBow = true;
+        gameManager.SaveGame();
+        if (puzzleManager != null)
         {
             puzzleManager.bowCollected = true;
         }

--- a/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/TwoDMirror.cs
+++ b/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/TwoDMirror.cs
@@ -1,9 +1,8 @@
- using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class TwoDMirror : MonoBehaviour
 {
+    GameManager gameManager;
     public bool pickUpAllowed = false;
     public bool pickedUp = false;
 
@@ -11,47 +10,47 @@ public class TwoDMirror : MonoBehaviour
     public bool isInRangeOfEnemy;
 
     public float slowingValue;
-    public LeverPuzzleManager leverManager;
-    
 
-    // Start is called before the first frame update
-    void Start()
+    private void Start()
     {
-        
+        if (GameManager.instance != null) gameManager = GameManager.instance;
+        else Debug.LogWarning("GameManager Missing.");
     }
-                                        
-    // Update is called once per frame
     void Update()
     {
-        if(pickUpAllowed == true && Input.GetKeyDown(KeyCode.E))
+        if (!pickUpAllowed) return;
+
+        if(Input.GetKeyDown(KeyCode.E))
         {
             PickUp();
         }
 
     }
-
-    private void OnTriggerEnter2D(Collider2D other) 
+    private void OnTriggerEnter2D(Collider2D other)
     {
-        if(other.gameObject.tag == "Player")
+        if (other.gameObject.tag == "Player")
         {
+            gameManager.Popup("Press E to Pick up", true);
+
             pickUpAllowed = true;
         }
     }
 
-    private void OnTriggerExit2D(Collider2D other) 
+    private void OnTriggerExit2D(Collider2D other)
     {
-        if(other.gameObject.tag == "Player")
+        if (other.gameObject.tag == "Player")
         {
+            gameManager.Popup("Press E to Pick up", false);
+
             pickUpAllowed = false;
         }
     }
 
-
-
     private void PickUp()
     {
         pickedUp = true;
-        leverManager.CollectMirror();
+        gameManager.gameData.collectedMirror = true;
+        gameManager.SaveGame();
         gameObject.SetActive(false);
     }
 
@@ -62,7 +61,6 @@ public class TwoDMirror : MonoBehaviour
         foreach(MouseAI enemy in enemies)
         {
             enemy.SetMovementSpeed(slowingValue);
-
         }
     }
 

--- a/Mythology Mayhem/Assets/2D Assets/Greek/2Dpuzzle/ElementalPuzzleItem.cs
+++ b/Mythology Mayhem/Assets/2D Assets/Greek/2Dpuzzle/ElementalPuzzleItem.cs
@@ -13,97 +13,31 @@ public class ElementalPuzzleItem : MonoBehaviour
 
     public Item item;
 
-    void Update()
-    {
-        if(puzzleManager == null)
-        {
-            FindPuzzleManager();
-        }
-    }
-
-    void FindPuzzleManager()
-    {
-        PedastalsPuzzleManager[] puzzleManagers = FindObjectsOfType<PedastalsPuzzleManager>();
-        foreach (var tempManager in puzzleManagers)
-        {
-            if(tempManager.gameObject.scene.buildIndex == -1)
-            {
-                puzzleManager = tempManager;
-                switch (item)
-                {
-                    case Item.Apple:
-                        if(puzzleManager.apple)
-                        {
-                            Destroy(gameObject);
-                        }
-                        break;
-                    case Item.Torch:
-                        if(puzzleManager.torch)
-                        {
-                            Destroy(gameObject);
-                        }
-                        break;
-                    case Item.Fish:
-                        if(puzzleManager.fish)
-                        {
-                            Destroy(gameObject);
-                        }
-                        break;
-                    case Item.Air:
-                        if(puzzleManager.air)
-                        {
-                            Destroy(gameObject);
-                        }
-                        break;
-                }
-            }
-        }
-    }
-
     private void OnTriggerEnter(Collider other) 
     {
 
-        if(other.tag != "Player" )
+        if (other.gameObject.tag == "Player")
         {
-            return;
-        }
-
-        switch(item)
-        {
-            case Item.Apple:
-            
-                
-                itemTransfer.apple = true;
-                //PlayerPrefs.SetInt("appleBool", itemTransfer.apple ? 1 :0);
-                puzzleManager.apple = true;
-                
-                break;
-             case Item.Torch:
-
-                
+            switch (item)
+            {
+                case Item.Apple:
+                    itemTransfer.apple = true;
+                    puzzleManager.apple = true;
+                    break;
+                case Item.Torch:
                     itemTransfer.torch = true;
-                    //PlayerPrefs.SetInt("torchBool", itemTransfer.torch ? 1 :0);
                     puzzleManager.torch = true;
-                
-                break;
-             case Item.Fish:
-                
-                
+                    break;
+                case Item.Fish:
                     itemTransfer.fish = true;
-                    //PlayerPrefs.SetInt("fishBool", itemTransfer.fish ? 1 :0);
                     puzzleManager.fish = true;
-                
-                break;
-             case Item.Air:
-               
-                
+                    break;
+                case Item.Air:
                     itemTransfer.air = true;
-                    //PlayerPrefs.SetInt("airBool", itemTransfer.air ? 1 :0);
                     puzzleManager.air = true;
-                
-                break;
+                    break;
+            }
+            Destroy(gameObject);
         }
-
-        Destroy(gameObject);
     }
 }

--- a/Mythology Mayhem/Assets/2D Assets/Greek/2Dpuzzle/LeverPuzzle.cs
+++ b/Mythology Mayhem/Assets/2D Assets/Greek/2Dpuzzle/LeverPuzzle.cs
@@ -7,81 +7,65 @@ using UnityEngine.SceneManagement;
 
 public class LeverPuzzle : MonoBehaviour
 {
+    GameManager gameManager;
     public Animator anim;
 
     public bool inRange = false;
     public bool switchOn = false;
-  
+    bool canOpen = false;
+
     // Start is called before the first frame update
     void Start()
     {
-        anim = GetComponent<Animator>();
+        if (GetComponent<Animator>() != null) anim = GetComponent<Animator>();
+        else Debug.LogWarning("Animator Missing.");
 
         if (GameManager.instance != null) 
         {
+            gameManager = GameManager.instance;
             LoadState(GameManager.instance.gameData.GL2D_Lever);
         }
+        else Debug.LogWarning("GameManager Missing.");
     }
 
     // Update is called once per frame
     void Update()
     {
-        TwoDSwitchOnOff();
+        if (!canOpen) return;
+        if (Input.GetKeyDown(KeyCode.E)) TwoDSwitchOnOff();
     }
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        if (other.gameObject.layer == 3) 
+        if (other.gameObject.tag == "Player")
         {
-            inRange = true;
-        }
+            gameManager.Popup("Press E to Pull Lever", true);
 
+            canOpen = true;
+        }
     }
 
     private void OnTriggerExit2D(Collider2D other)
     {
-        if (other.gameObject.layer  == 3)
+        if (other.gameObject.tag == "Player")
         {
-            inRange = false;
+            gameManager.Popup("Press E to Pull Lever", false);
+
+            canOpen = false;
         }
     }
 
     private void TwoDSwitchOnOff()
     {
-        if (inRange == true && Input.GetKeyDown("1") && !switchOn)
-        {
-            anim.Play("LeverAnim");
-            switchOn = true;
-        }
-        else if (inRange == true && Input.GetKeyDown("2") && switchOn)
-        {
-            anim.Play("LeverOff");
-            switchOn = false;
-        }
-
-        if (inRange == true && Input.GetKey(KeyCode.E) && !switchOn)
-        {
-            anim.Play("LeverAnim");
-            switchOn = true;
-        }
-        else if (inRange == true && Input.GetKey(KeyCode.E) && switchOn)
-        {
-            anim.Play("LeverOff");
-            switchOn = false;
-        }
+        if (!switchOn) anim.Play("LeverAnim");
+        else anim.Play("LeverOff");
+        switchOn = !switchOn;
     }
 
     public void LoadState(bool on) 
     {
-        if (on)
-        {
-            anim.Play("LeverAnim");
-            switchOn = true;
-        }
-        else 
-        {
-            anim.Play("LeverOff");
-            switchOn = false;
-        }
+        if (on) anim.Play("LeverAnim");
+        else anim.Play("LeverOff");
+        switchOn = on;
     }
 }

--- a/Mythology Mayhem/Assets/2D Assets/Greek/2Dpuzzle/PedastalsPuzzle.cs
+++ b/Mythology Mayhem/Assets/2D Assets/Greek/2Dpuzzle/PedastalsPuzzle.cs
@@ -1,115 +1,140 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.UI;
 
 public class PedastalsPuzzle : MonoBehaviour
 {
-    private PedastalsPuzzleManager puzzleManager;
+    GameManager gameManager;
+    public PedastalsPuzzleManager puzzleManager;
     public ElementalPuzzleItem.Item item;
 
 
     public SpriteRenderer elementalIcon;
-    [SerializeField] private bool isPlayerInRange = false;
-
-
-    // Start is called before the first frame update
-    void Awake()
+    public bool hasItem = false;
+    private void Start()
     {
-        puzzleManager = FindObjectOfType<PedastalsPuzzleManager>();
-        if (puzzleManager != null)
+        if (GameManager.instance != null) gameManager = GameManager.instance;
+        else Debug.LogWarning("GameManager Missing.");
+
+        if (FindObjectOfType<PedastalsPuzzleManager>() != null) puzzleManager = FindObjectOfType<PedastalsPuzzleManager>();
+        else Debug.LogWarning("PedastalsPuzzleManager Missing.");
+
+        switch (item)
         {
-            switch (item)
-            {
-                case ElementalPuzzleItem.Item.Fish:
-                    if (puzzleManager.fishDone)
-                    {
-                        elementalIcon.color = new Color(1, 1, 1);
-                    }
-                    break;
-                case ElementalPuzzleItem.Item.Apple:
-                    if (puzzleManager.appleDone)
-                    {
-                        elementalIcon.color = new Color(1, 1, 1);
-                    }
-                    break;
-                case ElementalPuzzleItem.Item.Torch:
-                    if (puzzleManager.torchDone)
-                    {
-                        elementalIcon.color = new Color(1, 1, 1);
-                    }
-                    break;
-                case ElementalPuzzleItem.Item.Air:
-                    if (puzzleManager.airDone)
-                    {
-                        elementalIcon.color = new Color(1, 1, 1);
-                    }
-                    break;
-            }
+            case ElementalPuzzleItem.Item.Apple:
+                if (puzzleManager.appleDone) elementalIcon.color = Color.white;
+                else elementalIcon.color = Color.black;
+                break;
+            case ElementalPuzzleItem.Item.Torch:
+                if (puzzleManager.torchDone) elementalIcon.color = Color.white;
+                else elementalIcon.color = Color.black;
+                break;
+            case ElementalPuzzleItem.Item.Fish:
+                if (puzzleManager.fishDone) elementalIcon.color = Color.white;
+                else elementalIcon.color = Color.black;
+                break;
+            case ElementalPuzzleItem.Item.Air:
+                if (puzzleManager.airDone) elementalIcon.color = Color.white;
+                else elementalIcon.color = Color.black;
+                break;
+            default:
+                break;
         }
     }
 
     // Update is called once per frame
     void Update()
     {
-        if(Input.GetKeyDown(KeyCode.E))
+        if (!hasItem) return;
+
+        if (Input.GetKeyDown(KeyCode.E))
         {
-            Debug.Log("E key is pressed!");
-            if (isPlayerInRange)
+            Debug.Log(item);
+            switch (item)
             {
-                if(item == ElementalPuzzleItem.Item.Fish && puzzleManager.fish && !puzzleManager.fishDone)
-                {
-                    Debug.Log("Fish is true!");
-                    elementalIcon.color = new Color(1, 1, 1);
-                    puzzleManager.fishDone = true;
-                    
-                }
-                else if(item == ElementalPuzzleItem.Item.Apple && puzzleManager.apple && !puzzleManager.appleDone )
-                {
-                    elementalIcon.color = new Color(1, 1, 1);
-                    puzzleManager.appleDone = true;
-                }
-                else if(item == ElementalPuzzleItem.Item.Torch && puzzleManager.torch && !puzzleManager.torchDone)
-                {
-                    elementalIcon.color = new Color(1, 1, 1);
-                    puzzleManager.torchDone = true;
-                }
-                else if(item == ElementalPuzzleItem.Item.Air && puzzleManager.air && !puzzleManager.airDone)
-                {
-                    elementalIcon.color = new Color(1, 1, 1);
-                    puzzleManager.airDone = true;
-                }
-                puzzleManager.UpdateDoor();
+                case ElementalPuzzleItem.Item.Apple:
+                    if (!puzzleManager.appleDone)
+                    {
+                        elementalIcon.color = Color.white;
+                        puzzleManager.appleDone = true;
+                    }
+                    break;
+                case ElementalPuzzleItem.Item.Torch:
+                    if (!puzzleManager.torchDone)
+                    {
+                        elementalIcon.color = Color.white;
+                        puzzleManager.torchDone = true;
+                    }
+                    break;
+                case ElementalPuzzleItem.Item.Fish:
+                    if (!puzzleManager.fishDone)
+                    {
+                        elementalIcon.color = Color.white;
+                        puzzleManager.fishDone = true;
+                    }
+                    break;
+                case ElementalPuzzleItem.Item.Air:
+                    if (!puzzleManager.airDone)
+                    {
+                        elementalIcon.color = Color.white;
+                        puzzleManager.airDone = true;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            puzzleManager.UpdateDoor();
+        }        
+    }
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.gameObject.tag == "Player")
+        {
+            switch (item)
+            {
+                case ElementalPuzzleItem.Item.Apple:
+                    if (puzzleManager.apple)
+                    {
+                        gameManager.Popup("Press E to Place Item", true);
+                        hasItem = true;
+                    }
+                    else gameManager.Popup("Item Missing\nReturn to the Labyrinth", true);
+                    break;
+                case ElementalPuzzleItem.Item.Torch:
+                    if (puzzleManager.torch)
+                    {
+                        gameManager.Popup("Press E to Place Item", true);
+                        hasItem = true;
+                    }
+                    else gameManager.Popup("Item Missing\nReturn to the Labyrinth", true);
+                    break;
+                case ElementalPuzzleItem.Item.Fish:
+                    if (puzzleManager.fish)
+                    {
+                        gameManager.Popup("Press E to Place Item", true);
+                        hasItem = true;
+                    }
+                    else gameManager.Popup("Item Missing\nReturn to the Labyrinth", true);
+                    break;
+                case ElementalPuzzleItem.Item.Air:
+                    if (puzzleManager.air)
+                    {
+                        gameManager.Popup("Press E to Place Item", true);
+                        hasItem = true;
+                    }
+                    else gameManager.Popup("Item Missing\nReturn to the Labyrinth", true);
+                    break;
+                default:
+                    break;
             }
         }
-        
     }
 
-
-    private void OnTriggerEnter2D(Collider2D other) 
+    private void OnTriggerExit2D(Collider2D other)
     {
-        if(other.tag != "Player")
+        if (other.gameObject.tag == "Player")
         {
-            return;
-        }
-        else
-        {
-            isPlayerInRange = true;
-            Debug.Log("Player is inside the trigger!");
+            gameManager.Popup("Press E to Pick up", false);
+
+            hasItem = false;
         }
     }
-
-    private void OnTriggerExit2D(Collider2D other) 
-    {
-        if(other.tag != "Player")
-        {
-            return;
-        }
-        else
-        {
-            isPlayerInRange = false;
-            Debug.Log("Player is inside the trigger!");
-        }
-    }
-
 }

--- a/Mythology Mayhem/Assets/2D Assets/Greek/2Dpuzzle/PedastalsPuzzleManager.cs
+++ b/Mythology Mayhem/Assets/2D Assets/Greek/2Dpuzzle/PedastalsPuzzleManager.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class PedastalsPuzzleManager : MonoBehaviour
 {
+    GameManager gameManager;
     public  bool fish;
     public  bool apple;
     public  bool torch;
@@ -14,39 +15,37 @@ public class PedastalsPuzzleManager : MonoBehaviour
     public bool torchDone;
     public bool airDone;
 
-    public GameObject door;
-    
-    //public GameObject SpawnLocation
+    public SceneTransitionPoint2D door;
+    public string nextSceneName = "GreekAthens_2D";
     public GameObject itemBow;
     public bool bowCollected;
 
-    // Start is called before the first frame update
-    void Awake()
+    private void Start()
     {
-        PedastalsPuzzleManager[] puzzleManagers = FindObjectsOfType<PedastalsPuzzleManager>();
-        //Debug.Log(puzzleManagers.Length);
-        //if(puzzleManagers.Length > 1)
-        //{
-        //    Destroy(this.gameObject);
-        //}
-        //else
-        //{
-        //    DontDestroyOnLoad(this.gameObject);
-        //}
+        if (GameManager.instance != null) gameManager = GameManager.instance;
+        else Debug.LogWarning("GameManager Missing.");
     }
-
-    // Update is called once per frame
-    void Update()
-    {
-       
-    }
-
     public void UpdateDoor()
     {
-        if(fishDone && appleDone && torchDone && airDone)
+        if (door == null)
         {
-            door.GetComponent<DoorCode>().doorOpen = true;
-            door.GetComponent<DoorCode>().blocked = false;
+            foreach (SceneTransitionPoint2D d in FindObjectsOfType<SceneTransitionPoint2D>())
+            {
+                if (d.gameObject.scene.name == gameManager.currentScene.ToString())
+                {
+                    if (d.sceneToTransition.ToString() == nextSceneName)
+                    {
+                        door = d;
+                        door.enabled = false;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (fishDone && appleDone && torchDone && airDone)
+        {
+            door.enabled = true;
             
             if(itemBow.GetComponent<TwoDBow>().pickedUp == false)
             {

--- a/Mythology Mayhem/Assets/3D Assets/Global/Scripts/WeaponSwitcher.cs
+++ b/Mythology Mayhem/Assets/3D Assets/Global/Scripts/WeaponSwitcher.cs
@@ -1,9 +1,11 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using UnityEngine;
 
 public class WeaponSwitcher : MythologyMayhem
 {
+    GameManager gameManager;
     public MainHand currentMain;
     public OffHand currentOffHand;
 
@@ -13,8 +15,16 @@ public class WeaponSwitcher : MythologyMayhem
 
     [Header("Left Hand")]
     public GameObject[] LeftHandWeapons;
-    int currentLeftHandWeapon;    
+    int currentLeftHandWeapon;
 
+    private void Start()
+    {
+        if (GameManager.instance != null) gameManager = GameManager.instance;
+        else Debug.LogWarning("GameManager Missing.");
+
+        if (gameManager.gameData.collectedMirror) LeftHandWeapons[1].SetActive(true);
+        else LeftHandWeapons[1].SetActive(false);
+    }
     // Update is called once per frame
     void Update()
     {
@@ -22,24 +32,14 @@ public class WeaponSwitcher : MythologyMayhem
         if (Input.GetKeyDown(KeyCode.Alpha1)) 
         {
             //Iterate Next Weapon
-            if(currentRightHandWeapon + 1 >= RightHandWeapons.Length)
-            {
-                currentRightHandWeapon = 0;
-            } else
-            {
-                currentRightHandWeapon++;
-            }
+            if(currentRightHandWeapon + 1 >= RightHandWeapons.Length) currentRightHandWeapon = 0;
+            else currentRightHandWeapon++;
 
             //Activate Next Weapon, Deactivate Other Weapons
             for(int i = 0; i < RightHandWeapons.Length; i++)
             {
-                if(i == currentRightHandWeapon)
-                {
-                    RightHandWeapons[i].SetActive(true);
-                } else
-                {
-                    RightHandWeapons[i].SetActive(false);
-                }
+                if(i == currentRightHandWeapon) RightHandWeapons[i].SetActive(true);
+                else RightHandWeapons[i].SetActive(false);
             }
 
             //Set Current Main
@@ -67,26 +67,19 @@ public class WeaponSwitcher : MythologyMayhem
         if (Input.GetKeyDown(KeyCode.Alpha2)) 
         {
             //Iterate Next Weapon
-            if (currentLeftHandWeapon + 1 >= LeftHandWeapons.Length)
+            if (currentLeftHandWeapon + 1 >= LeftHandWeapons.Length) currentLeftHandWeapon = 0;
+            else currentLeftHandWeapon++;
+
+            if (LeftHandWeapons[currentLeftHandWeapon].name == "GreekMirror3D")
             {
-                currentLeftHandWeapon = 0;
-            }
-            else
-            {
-                currentLeftHandWeapon++;
+                if (!gameManager.gameData.collectedMirror) currentLeftHandWeapon++;
             }
 
             //Activate Next Weapon, Deactivate Other Weapons
             for (int i = 0; i < LeftHandWeapons.Length; i++)
             {
-                if (i == currentLeftHandWeapon)
-                {
-                    LeftHandWeapons[i].SetActive(true);
-                }
-                else
-                {
-                    LeftHandWeapons[i].SetActive(false);
-                }
+                if (i == currentLeftHandWeapon) LeftHandWeapons[i].SetActive(true);
+                else LeftHandWeapons[i].SetActive(false);
             }
 
             //Set Current Main
@@ -116,6 +109,5 @@ public class WeaponSwitcher : MythologyMayhem
             //        break;
             //}
         }
-
     }
 }

--- a/Mythology Mayhem/Assets/Global Assets/Art/Fantasy Loot Pack/Materials/Gem-Orange.mat
+++ b/Mythology Mayhem/Assets/Global Assets/Art/Fantasy Loot Pack/Materials/Gem-Orange.mat
@@ -2,22 +2,29 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!21 &2100000
 Material:
-  serializedVersion: 6
+  serializedVersion: 8
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: Gem-Orange
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
-  stringTagMap: {}
+  stringTagMap:
+    RenderType: Opaque
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 2800000, guid: 61e0d5ceb23f3d04597826d9768355b4, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _BumpMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -58,16 +65,40 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _ToonShade:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
     m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
     - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
     - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _EmissionLM: 0
+    - _EnvironmentReflections: 1
     - _GlossMapScale: 1
     - _Glossiness: 0
     - _GlossyReflections: 1
@@ -75,14 +106,34 @@ Material:
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
     - _Shininess: 0.7
+    - _Smoothness: 0
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _Surface: 0
     - _UVSec: 0
+    - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _Emission: {r: 0.38608983, g: 0.41911763, b: 0.07704368, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0, g: 0, b: 0, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &2504803912096180257
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5

--- a/Mythology Mayhem/Assets/Global Assets/Prefabs/GameManager/GameManager.prefab
+++ b/Mythology Mayhem/Assets/Global Assets/Prefabs/GameManager/GameManager.prefab
@@ -1303,6 +1303,7 @@ MonoBehaviour:
   - {fileID: 21300000, guid: b0910b61f36125448a2ad24c370f1f02, type: 3}
   - {fileID: 21300000, guid: 435b8628723a71741a117b94d0cf36cd, type: 3}
   - {fileID: 21300000, guid: f5c517d27d132f74bbeec7121e4a3c5a, type: 3}
+  ship_states: []
   ps: {fileID: 0}
 --- !u!1 &2396654760646885180
 GameObject:
@@ -12376,7 +12377,7 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8451108749532077064}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!1 &8723804945251903353
 GameObject:
   m_ObjectHideFlags: 0
@@ -13047,14 +13048,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 04f0dd68a7311264793b00f22bea299f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _heartUXML: {fileID: 9197481963319205126, guid: d5d1704df7de53a49a1e7fdbcd5c365c, type: 3}
+  heartState: {fileID: 0}
   _heartModes:
   - {fileID: 21300000, guid: cef072df35a8041449c480ffe2f70c5f, type: 3}
   - {fileID: 21300000, guid: eb210f6803b2b10489e9bc3355a60e4b, type: 3}
   - {fileID: 21300000, guid: b0910b61f36125448a2ad24c370f1f02, type: 3}
   - {fileID: 21300000, guid: 435b8628723a71741a117b94d0cf36cd, type: 3}
   - {fileID: 21300000, guid: f5c517d27d132f74bbeec7121e4a3c5a, type: 3}
-  _shipUXML: {fileID: 9197481963319205126, guid: 2e1922316a54f004b853c52048419d62, type: 3}
   _shipModes:
   - {fileID: 21300000, guid: a07acce4eb380fd43ad416c3300d9105, type: 3}
   - {fileID: 21300000, guid: 7cfeade0a12ebff46bf2fa100dc1688f, type: 3}

--- a/Mythology Mayhem/Assets/Global Assets/Scenes/2D Scenes/Greek 2D/Labyrinth_Scenes/GreekLabyrinth_2D_Levers.unity
+++ b/Mythology Mayhem/Assets/Global Assets/Scenes/2D Scenes/Greek 2D/Labyrinth_Scenes/GreekLabyrinth_2D_Levers.unity
@@ -734,7 +734,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1674893149}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &455832558
 PrefabInstance:
@@ -1140,7 +1140,7 @@ Transform:
   - {fileID: 1498581248}
   - {fileID: 417137842}
   m_Father: {fileID: 1674893149}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &694201511
 GameObject:
@@ -1190,7 +1190,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1674893149}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &719968869 stripped
 GameObject:
@@ -1383,6 +1383,10 @@ MonoBehaviour:
   keyPress: 0
   isActive: 1
   conditions: []
+  countAsLevelComplete: 0
+  completedChapter: 0
+  completedLevel: 0
+  canTransition: 0
 --- !u!1 &894277773 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7692487075164556626, guid: 3be78a4060179e342817f52d0af16709, type: 3}
@@ -1932,7 +1936,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 1674893149}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1338900937
 MonoBehaviour:
@@ -1951,7 +1955,6 @@ MonoBehaviour:
   isEquipped: 0
   isInRangeOfEnemy: 0
   slowingValue: 2
-  leverManager: {fileID: 0}
 --- !u!61 &1338900938
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -2243,7 +2246,7 @@ Transform:
   - {fileID: 1208276694}
   - {fileID: 1872502283}
   m_Father: {fileID: 1674893149}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1613825275
 PrefabInstance:
@@ -2297,6 +2300,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4734550838967186337, guid: 7a794babc7ff30a4b9108c104e65f406, type: 3}
+      propertyPath: inScene
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4734550838967186337, guid: 7a794babc7ff30a4b9108c104e65f406, type: 3}
       propertyPath: useCustom
       value: 0
       objectReference: {fileID: 0}
@@ -2323,6 +2330,10 @@ PrefabInstance:
     - target: {fileID: 4734550838967186337, guid: 7a794babc7ff30a4b9108c104e65f406, type: 3}
       propertyPath: scenesNeeded.Array.size
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4734550838967186337, guid: 7a794babc7ff30a4b9108c104e65f406, type: 3}
+      propertyPath: scenesNeeded.Array.data[0]
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4734550838967186337, guid: 7a794babc7ff30a4b9108c104e65f406, type: 3}
       propertyPath: scenesNeeded.Array.data[1]
@@ -2508,7 +2519,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1613825277}
-  - {fileID: 2143040802}
   - {fileID: 649517426}
   - {fileID: 1613129544}
   - {fileID: 1825499677}
@@ -2863,7 +2873,7 @@ Transform:
   - {fileID: 617050629}
   - {fileID: 1087078347}
   m_Father: {fileID: 1674893149}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1825499678
 MonoBehaviour:
@@ -3211,65 +3221,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3be78a4060179e342817f52d0af16709, type: 3}
---- !u!1 &2143040800
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2143040802}
-  - component: {fileID: 2143040803}
-  m_Layer: 0
-  m_Name: GameManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2143040802
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2143040800}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -64.46921, y: 0.6091037, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1674893149}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2143040803
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2143040800}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 31fcbfe5ed8a87846a830abb3c76df79, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  levers:
-  - {fileID: 719968878}
-  - {fileID: 1933163909}
-  - {fileID: 1426302699}
-  - {fileID: 2031968971}
-  - {fileID: 1696576947}
-  - {fileID: 2060959655}
-  - {fileID: 1643751809}
-  - {fileID: 1295793905}
-  - {fileID: 1254682752}
-  - {fileID: 1087078353}
-  combination: 00000001000001000001
-  match: 0
-  Door: {fileID: 1208276690}
-  item: {fileID: 1338900934}
-  mirrorCollected: 0
-  loading: 0
-  completed: 0

--- a/Mythology Mayhem/Assets/Global Assets/Scenes/2D Scenes/Greek 2D/Labyrinth_Scenes/GreekLabyrinth_2D_Pedastals.unity
+++ b/Mythology Mayhem/Assets/Global Assets/Scenes/2D Scenes/Greek 2D/Labyrinth_Scenes/GreekLabyrinth_2D_Pedastals.unity
@@ -391,6 +391,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2874544876076593519, guid: 49fd3c7eccb05494791cd356283d5a16, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2874544876076593519, guid: 49fd3c7eccb05494791cd356283d5a16, type: 3}
       propertyPath: nextLevel
       value: Athens
       objectReference: {fileID: 0}
@@ -404,7 +408,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2874544876076593523, guid: 49fd3c7eccb05494791cd356283d5a16, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 2874544876076593523, guid: 49fd3c7eccb05494791cd356283d5a16, type: 3}
       propertyPath: m_LocalPosition.x
@@ -626,6 +630,10 @@ MonoBehaviour:
   keyPress: 0
   isActive: 1
   conditions: []
+  countAsLevelComplete: 0
+  completedChapter: 0
+  completedLevel: 0
+  canTransition: 0
 --- !u!1001 &409257012
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -663,9 +671,17 @@ PrefabInstance:
       propertyPath: elementalIcon
       value: 
       objectReference: {fileID: 1965324858}
+    - target: {fileID: 5984320118888385000, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
+      propertyPath: puzzleManager
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 5984320118888385004, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
       propertyPath: m_Name
       value: Air Pedestal
+      objectReference: {fileID: 0}
+    - target: {fileID: 5984320118888385006, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5984320118888385007, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
       propertyPath: m_RootOrder
@@ -722,37 +738,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5984320118888385007, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
   m_PrefabInstance: {fileID: 409257012}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &417137841
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 417137842}
-  m_Layer: 0
-  m_Name: Enemies
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &417137842
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 417137841}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -44.732056, y: -0.86730766, z: -5.1706786}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1234357238}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &450419632 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5984320118888385004, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
@@ -812,6 +797,10 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2874544876076593519, guid: 49fd3c7eccb05494791cd356283d5a16, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2874544876076593519, guid: 49fd3c7eccb05494791cd356283d5a16, type: 3}
       propertyPath: nextLevel
       value: Labyrinth 3D
       objectReference: {fileID: 0}
@@ -823,9 +812,13 @@ PrefabInstance:
       propertyPath: m_Name
       value: Door1
       objectReference: {fileID: 0}
+    - target: {fileID: 2874544876076593522, guid: 49fd3c7eccb05494791cd356283d5a16, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2874544876076593523, guid: 49fd3c7eccb05494791cd356283d5a16, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 2874544876076593523, guid: 49fd3c7eccb05494791cd356283d5a16, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1089,7 +1082,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1234357238}
-  m_RootOrder: 11
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!61 &543559167
 BoxCollider2D:
@@ -1285,6 +1278,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4734550838967186337, guid: 7a794babc7ff30a4b9108c104e65f406, type: 3}
+      propertyPath: inScene
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 4734550838967186337, guid: 7a794babc7ff30a4b9108c104e65f406, type: 3}
       propertyPath: useCustom
       value: 0
       objectReference: {fileID: 0}
@@ -1311,6 +1308,10 @@ PrefabInstance:
     - target: {fileID: 4734550838967186337, guid: 7a794babc7ff30a4b9108c104e65f406, type: 3}
       propertyPath: scenesNeeded.Array.size
       value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4734550838967186337, guid: 7a794babc7ff30a4b9108c104e65f406, type: 3}
+      propertyPath: scenesNeeded.Array.data[0]
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 4734550838967186337, guid: 7a794babc7ff30a4b9108c104e65f406, type: 3}
       propertyPath: scenesNeeded.Array.data[1]
@@ -1550,7 +1551,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1234357238}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &847382521 stripped
 GameObject:
@@ -1588,37 +1589,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.28, y: 3.2600508}
   m_EdgeRadius: 0
---- !u!1 &856255479
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 856255480}
-  m_Layer: 0
-  m_Name: Elementals
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &856255480
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 856255479}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -4.145233, y: -0.3357792, z: 20.232588}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1234357238}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &884222789 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 938562570768042669, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
@@ -1680,7 +1650,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1234357238}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1079870715
 GameObject:
@@ -1815,6 +1785,10 @@ MonoBehaviour:
   keyPress: 0
   isActive: 1
   conditions: []
+  countAsLevelComplete: 0
+  completedChapter: 0
+  completedLevel: 0
+  canTransition: 0
 --- !u!1001 &1178158270
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1854,9 +1828,17 @@ PrefabInstance:
       propertyPath: elementalIcon
       value: 
       objectReference: {fileID: 597699481}
+    - target: {fileID: 5984320118888385000, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
+      propertyPath: puzzleManager
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 5984320118888385004, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
       propertyPath: m_Name
       value: Fire Pedestal
+      objectReference: {fileID: 0}
+    - target: {fileID: 5984320118888385006, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5984320118888385007, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
       propertyPath: m_RootOrder
@@ -2003,12 +1985,10 @@ Transform:
   - {fileID: 30157074}
   - {fileID: 694201513}
   - {fileID: 1825499677}
-  - {fileID: 417137842}
   - {fileID: 1208276694}
   - {fileID: 924828307}
   - {fileID: 822965458}
   - {fileID: 106434803}
-  - {fileID: 856255480}
   - {fileID: 543559166}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -2132,9 +2112,17 @@ PrefabInstance:
       propertyPath: elementalIcon
       value: 
       objectReference: {fileID: 1542431223}
+    - target: {fileID: 5984320118888385000, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
+      propertyPath: puzzleManager
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 5984320118888385004, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
       propertyPath: m_Name
       value: 'Earth Pedestal '
+      objectReference: {fileID: 0}
+    - target: {fileID: 5984320118888385006, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5984320118888385007, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
       propertyPath: m_RootOrder
@@ -2544,9 +2532,17 @@ PrefabInstance:
       propertyPath: elementalIcon
       value: 
       objectReference: {fileID: 1775440069}
+    - target: {fileID: 5984320118888385000, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
+      propertyPath: puzzleManager
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 5984320118888385004, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
       propertyPath: m_Name
       value: Water Pedestal
+      objectReference: {fileID: 0}
+    - target: {fileID: 5984320118888385006, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5984320118888385007, guid: 011fbba29a683c34283e4415d93b49c7, type: 3}
       propertyPath: m_RootOrder

--- a/Mythology Mayhem/Assets/Global Assets/Scenes/3D Scenes/Greek 3D/GreekLabyrinth_3D.unity
+++ b/Mythology Mayhem/Assets/Global Assets/Scenes/3D Scenes/Greek 3D/GreekLabyrinth_3D.unity
@@ -145,7 +145,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8e7a0b9f29e6de7458640938d5f8f998, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  puzzleManager: {fileID: 0}
+  puzzleManager: {fileID: 390860010}
   itemTransfer: {fileID: 11400000, guid: c461bab2e01acd24c861bc7f2fa95800, type: 2}
   item: 2
 --- !u!1001 &91527475
@@ -219,6 +219,10 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: -0.0087
       objectReference: {fileID: 0}
+    - target: {fileID: 2300131514293983079, guid: e5f81f7eeb83527419833600e2bf4abd, type: 3}
+      propertyPath: gem
+      value: 
+      objectReference: {fileID: 1895071795}
     - target: {fileID: 2300131514293983079, guid: e5f81f7eeb83527419833600e2bf4abd, type: 3}
       propertyPath: doorGem
       value: Gem-Green-Teardrop
@@ -583,6 +587,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2337726971492964521, guid: e716eaa1c95e0be409efd4a6b452b865, type: 3}
+      propertyPath: nextSceneName
+      value: GreekAthens_2D
+      objectReference: {fileID: 0}
     - target: {fileID: 2337726971492964526, guid: e716eaa1c95e0be409efd4a6b452b865, type: 3}
       propertyPath: m_Name
       value: PedstalPuzzleManager
@@ -594,6 +602,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2337726971492964520, guid: e716eaa1c95e0be409efd4a6b452b865, type: 3}
   m_PrefabInstance: {fileID: 390860008}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &390860010 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2337726971492964521, guid: e716eaa1c95e0be409efd4a6b452b865, type: 3}
+  m_PrefabInstance: {fileID: 390860008}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2bde20483c447504c97c47820597f936, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &429499509 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6091051967339103169, guid: 6aaa337f6bc304744a9fb58532ee3540, type: 3}
@@ -80612,7 +80631,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8e7a0b9f29e6de7458640938d5f8f998, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  puzzleManager: {fileID: 0}
+  puzzleManager: {fileID: 390860010}
   itemTransfer: {fileID: 11400000, guid: c461bab2e01acd24c861bc7f2fa95800, type: 2}
   item: 0
 --- !u!1 &884387364
@@ -80645,6 +80664,7 @@ Transform:
   m_Children:
   - {fileID: 1894980627}
   - {fileID: 1608591799}
+  - {fileID: 1908879761}
   m_Father: {fileID: 2071059264}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -81043,6 +81063,10 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: -0.0074954703
       objectReference: {fileID: 0}
+    - target: {fileID: 2300131514293983079, guid: e5f81f7eeb83527419833600e2bf4abd, type: 3}
+      propertyPath: gem
+      value: 
+      objectReference: {fileID: 1908879762}
     - target: {fileID: 2300131514293983079, guid: e5f81f7eeb83527419833600e2bf4abd, type: 3}
       propertyPath: doorGem
       value: Gem-Orange-Diamond
@@ -81488,6 +81512,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2300131514293983079, guid: e5f81f7eeb83527419833600e2bf4abd, type: 3}
+      propertyPath: gem
+      value: 
+      objectReference: {fileID: 1608955287}
     - target: {fileID: 2300131514293983079, guid: e5f81f7eeb83527419833600e2bf4abd, type: 3}
       propertyPath: m_Enabled
       value: 1
@@ -82922,6 +82950,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2300131514293983079, guid: e5f81f7eeb83527419833600e2bf4abd, type: 3}
+      propertyPath: gem
+      value: 
+      objectReference: {fileID: 1608955287}
+    - target: {fileID: 2300131514293983079, guid: e5f81f7eeb83527419833600e2bf4abd, type: 3}
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
@@ -82953,7 +82985,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8e7a0b9f29e6de7458640938d5f8f998, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  puzzleManager: {fileID: 0}
+  puzzleManager: {fileID: 390860010}
   itemTransfer: {fileID: 11400000, guid: c461bab2e01acd24c861bc7f2fa95800, type: 2}
   item: 1
 --- !u!65 &1834357950
@@ -83607,6 +83639,73 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1001 &1908879760
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 884387365}
+    m_Modifications:
+    - target: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 102.04293
+      objectReference: {fileID: 0}
+    - target: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.9016573
+      objectReference: {fileID: 0}
+    - target: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.37227058
+      objectReference: {fileID: 0}
+    - target: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2304417138347365411, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+      propertyPath: m_Name
+      value: Gem-Orange-Diamond
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+--- !u!4 &1908879761 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2304417138347329539, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+  m_PrefabInstance: {fileID: 1908879760}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1908879762 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2304417138347365411, guid: 9f6aebf51e8a29447b577f7960fce7f7, type: 3}
+  m_PrefabInstance: {fileID: 1908879760}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1980298106
 GameObject:
   m_ObjectHideFlags: 0
@@ -84180,7 +84279,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8e7a0b9f29e6de7458640938d5f8f998, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  puzzleManager: {fileID: 0}
+  puzzleManager: {fileID: 390860010}
   itemTransfer: {fileID: 11400000, guid: c461bab2e01acd24c861bc7f2fa95800, type: 2}
   item: 3
 --- !u!4 &2112257695 stripped

--- a/Mythology Mayhem/Assets/Global Assets/Scripts/DoorCode.cs
+++ b/Mythology Mayhem/Assets/Global Assets/Scripts/DoorCode.cs
@@ -17,7 +17,7 @@ public class DoorCode : MonoBehaviour
         if(nextLevel == "Athens" && gameObject.scene.ToString() == "2Dlabyrinth_Pedastals")
         {
             PedastalsPuzzleManager puzzleManager = FindObjectOfType<PedastalsPuzzleManager>();
-            puzzleManager.door = this.gameObject;
+            //puzzleManager.door = this.gameObject;
             
             if (puzzleManager.fishDone && puzzleManager.appleDone && puzzleManager.torchDone && puzzleManager.airDone)
             {

--- a/Mythology Mayhem/Assets/Global Assets/Scripts/QuizManager.cs
+++ b/Mythology Mayhem/Assets/Global Assets/Scripts/QuizManager.cs
@@ -45,7 +45,7 @@ public class QuizManager : MonoBehaviour
         score = 0;
         answered = false;
 
-        if (SaveScene.instance.saveData.collectedMirror)
+        if (GameManager.instance.gameData.collectedMirror)
         {
             question.text = introduction;
             answer1.text = "Begin";

--- a/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/GameData.cs
+++ b/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/GameData.cs
@@ -21,6 +21,7 @@ public class GameData : MythologyMayhem
     public int heartCollectionTotal;
     public bool[] collectedHearts;
     public bool collectedMirror;
+    public bool collectedBow;
     [Header("Main Menu")]
     public float masterVolume;
     public float musicVolume;

--- a/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/GameManager.cs
+++ b/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/GameManager.cs
@@ -65,6 +65,11 @@ public class GameManager : MythologyMayhem
     // Update is called once per frame
     void Update()
     {
+        if (Input.GetKeyDown(KeyCode.F1))
+        {
+            int index = loadedLocalManagers.IndexOf(currentLocalManager);
+            TransitionScene(loadedLocalManagers[index + 1].inScene, "");
+        }
         if (!startSceneDebugLoad)
         {
             bool inStartScene = SceneManager.GetSceneByName("StartScene").isLoaded;
@@ -301,12 +306,12 @@ public class GameManager : MythologyMayhem
             if (loadedLocalManagers[i].inScene == scene)
             {
                 currentLocalManager = loadedLocalManagers[i];
-                if (currentLocalManager.backgroundMusic != null) 
+                if (currentLocalManager.backgroundMusic != null)
                 {
                     backgroundMusic.clip = currentLocalManager.backgroundMusic;
                     backgroundMusic.Play();
                 }
-                return;
+                //return;
             }
         }
     }
@@ -335,14 +340,13 @@ public class GameManager : MythologyMayhem
                 currentPlayer.gameObject.SetActive(false);
                 currentPlayer.transform.position = currentLocalManager.activePlayerSpawner.spawnPoints[i].position;
                 currentPlayer.gameObject.SetActive(true);
-                break;
+                //break;
             }
         }
     }
 
-    public void TransitionScene(Level scene, string spawnpointOverride) 
+    public void TransitionScene(Level scene, string spawnpointOverride)
     {
-        Debug.Log("LoadScene");
         huic.UpdateHealth();
         Level previousScene = currentScene;
         currentScene = scene;

--- a/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/SceneTransitionPoint3D.cs
+++ b/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/SceneTransitionPoint3D.cs
@@ -30,6 +30,7 @@ public class SceneTransitionPoint3D : SceneTransitionPoint
 
             // transition to the next scene/level
             localGameManager.SceneTransition(sceneToTransition, spawnpointNameOverride);
+            canTransition = false;
         }
     }
 


### PR DESCRIPTION
TwoDBow: The bow can now be acquired by the player. Once the pedestal puzzle is completed the bow will appear and a pop up will display letting the player now to pick it up. Picking it up will update the game managers game data.
TwoDMirror: The mirror can now be acquired by the player. Once the lever puzzle is completed the mirror will appear and a pop up will display letting the player now to pick it up. Picking it up will update the game managers game data.
ElementalPuzzleItem: Removed code in the update loop. All code now runs on trigger enter.
LeverPuzzle: Optimized code to prevent code from running when not needed.
PedastalsPuzzle: Removed some code from the update loop. Simplified the switch statements.
PedastalsPuzzleManager: Removed references to the DoorCode script and replaced it with SceneTransitionPoint2D
WeaponSwitcher: The player can no longer equip the mirror if they do not have it.
GreekLabyrinth_3D: Added the orange diamond gem. The player can now access the GreekLabyrinth_2D_Pedastals scene.
QuizManager: Now checks the game data to see if the player has the mirror.
GameData: Added a ref to the bow.
GameManager: Added a helper function for testing that runs when the F1 key is pressed. This will transition the player to the next scene.