### PR TITLE
Build Bugs

### DIFF
--- a/Mythology Mayhem/Assets/Global Assets/Scenes/Menus/MainMenu.unity
+++ b/Mythology Mayhem/Assets/Global Assets/Scenes/Menus/MainMenu.unity
@@ -6433,6 +6433,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb6947084d08b93419ac94bee446e4b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  continueButton: {fileID: 997050439}
 --- !u!1 &1617937231
 GameObject:
   m_ObjectHideFlags: 0

--- a/Mythology Mayhem/Assets/Global Assets/Scripts/UI/UI/Menus/MenuManager.cs
+++ b/Mythology Mayhem/Assets/Global Assets/Scripts/UI/UI/Menus/MenuManager.cs
@@ -172,6 +172,8 @@ public class MenuManager : MonoBehaviour
     public void MainMenu() {
         Time.timeScale = 1;
         GameManager.instance.playerControllers.Clear();
+        GameManager.instance.loadedLocalManagers.Clear();
+        GameManager.instance.inMainMenu = true;
         SceneManager.LoadScene(0);
     }
 }

--- a/Mythology Mayhem/Assets/MainMenuController.cs
+++ b/Mythology Mayhem/Assets/MainMenuController.cs
@@ -1,14 +1,17 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class MainMenuController : MonoBehaviour
 {
     GameManager gameManager;
+    [SerializeField] Button continueButton;
 
     private void Start()
     {
         gameManager = GameManager.instance;
+        if (!System.IO.File.Exists(Application.persistentDataPath + "SaveData.json")) continueButton.enabled = false;
     }
     public void NewGame()
     {

--- a/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/LocalGameManager.cs
+++ b/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/LocalGameManager.cs
@@ -18,13 +18,13 @@ public class LocalGameManager : MythologyMayhem
     public Transform[] boundaries;
 
     public Level inScene;
-    [SerializeField] public List<Level> scenesNeeded;
-    [SerializeField] public List<Level> scenesLoadedOnStart;
-    [SerializeField] public List<ProximityLoad> scenesLoadedOnProximity;
-    [SerializeField] public List<SceneTransitionPoint> transitionPoints;
+    public List<Level> scenesNeeded;
+    public List<Level> scenesLoadedOnStart;
+    public List<ProximityLoad> scenesLoadedOnProximity;
+    public List<SceneTransitionPoint> transitionPoints;
     public bool loadNextOnStart;
 
-    [SerializeField] public playerSpawner activePlayerSpawner;
+    public playerSpawner activePlayerSpawner;
     public GameObject playerSpawnerPrefab;
     public GameObject spawnPointPrefab;
     public GameObject sceneTransitionPoint2D;

--- a/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/SaveData.cs
+++ b/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/SaveData.cs
@@ -283,7 +283,7 @@ public class SaveData
         Debug.Log("Save File");
         string sceneObjectsString = JsonUtility.ToJson(this, true);
 
-        System.IO.File.WriteAllText(Application.dataPath + "/Global Assets/Resources/SceneData/" + "TestSaveSystem" + ".json", sceneObjectsString);
+        System.IO.File.WriteAllText(Application.persistentDataPath + "SaveData.json", sceneObjectsString);
 
         //#if UNITY_EDITOR
         //    UnityEditor.AssetDatabase.Refresh();
@@ -293,14 +293,14 @@ public class SaveData
     public void Delete()
     {
         Debug.Log("Delete Saved File");
-        if (!System.IO.File.Exists(Application.dataPath + "/Global Assets/Resources/SceneData/" + "TestSaveSystem" + ".json")) return;
-        System.IO.File.Delete(Application.dataPath + "/Global Assets/Resources/SceneData/" + "TestSaveSystem" + ".json");
+        if (!System.IO.File.Exists(Application.persistentDataPath + "SaveData.json")) return;
+        System.IO.File.Delete(Application.persistentDataPath + "SaveData.json");
     }
     public void Load()
     {
-        if (!System.IO.File.Exists(Application.dataPath + "/Global Assets/Resources/SceneData/" + "TestSaveSystem" + ".json")) return;
+        if (!System.IO.File.Exists(Application.persistentDataPath + "SaveData.json")) return;
 
-        string sceneObjectsString = System.IO.File.ReadAllText(Application.dataPath + "/Global Assets/Resources/SceneData/" + "TestSaveSystem" + ".json");
+        string sceneObjectsString = System.IO.File.ReadAllText(Application.persistentDataPath + "SaveData.json");
 
         SaveData loadedData = JsonUtility.FromJson<SaveData>(sceneObjectsString);
         LoadData(loadedData);


### PR DESCRIPTION
Fixed a bug that would crash the build if the player tried to continue without a save file. Fixed a bug that would crash the build if the player returns to the main menu and tries to start a new game or continue. Changed the save data file path to not save to the game files directory.