### PR TITLE
2D/3D Greek Library

### DIFF
--- a/Mythology Mayhem/Assets/2D Assets/Greek/Enemies2D/Mouse.prefab
+++ b/Mythology Mayhem/Assets/2D Assets/Greek/Enemies2D/Mouse.prefab
@@ -181,7 +181,7 @@ Animator:
   m_GameObject: {fileID: 8389002920890670447}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 728148d8d4ceabb48803b100651383e7, type: 2}
+  m_Controller: {fileID: 9100000, guid: 3b7fcc074bf70fb4f899944839cdb2ad, type: 2}
   m_CullingMode: 0
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -550,7 +550,7 @@ MonoBehaviour:
   speed: 1
   patrolDistance: 2
   body: {fileID: 8389002920890670447}
-  attackTrigger: IsAttacking
+  attackTrigger: Attack
   meleeDistance: 5
   alertTimer: 3
   dropsScrolls: 0

--- a/Mythology Mayhem/Assets/Global Assets/Scenes/2D Scenes/Greek 2D/GreekLibrary_2D.unity
+++ b/Mythology Mayhem/Assets/Global Assets/Scenes/2D Scenes/Greek 2D/GreekLibrary_2D.unity
@@ -178,6 +178,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: attackTrigger
+      value: Attack
+      objectReference: {fileID: 0}
     - target: {fileID: 8389002920890670442, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_Controller
       value: 
@@ -243,6 +247,10 @@ PrefabInstance:
     - target: {fileID: 1547413830857976226, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: attackTrigger
+      value: Attack
       objectReference: {fileID: 0}
     - target: {fileID: 8389002920890670442, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_Controller
@@ -1183,6 +1191,10 @@ PrefabInstance:
     - target: {fileID: 1547413830857976226, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: attackTrigger
+      value: Attack
       objectReference: {fileID: 0}
     - target: {fileID: 8389002920890670442, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_Controller
@@ -2717,7 +2729,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 418183988}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 314.87, y: -1.96, z: 0}
+  m_LocalPosition: {x: 317.57, y: -1.96, z: 0}
   m_LocalScale: {x: 4.0479484, y: 2.5436516, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3612,6 +3624,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: attackTrigger
+      value: Attack
+      objectReference: {fileID: 0}
     - target: {fileID: 8389002920890670442, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_Controller
       value: 
@@ -4444,6 +4460,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: attackTrigger
+      value: Attack
+      objectReference: {fileID: 0}
     - target: {fileID: 8389002920890670442, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_Controller
       value: 
@@ -4899,7 +4919,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1033839214}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 304.21, y: -2.06, z: 0}
+  m_LocalPosition: {x: 306.9, y: -2.06, z: 0}
   m_LocalScale: {x: 5, y: 5, z: 5}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -6006,6 +6026,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: attackTrigger
+      value: Attack
+      objectReference: {fileID: 0}
     - target: {fileID: 8389002920890670442, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_Controller
       value: 
@@ -7086,6 +7110,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: attackTrigger
+      value: Attack
+      objectReference: {fileID: 0}
     - target: {fileID: 8389002920890670442, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_Controller
       value: 
@@ -7464,6 +7492,14 @@ PrefabInstance:
     - target: {fileID: 1547413830857976226, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: dropsScrolls
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: attackTrigger
+      value: Attack
       objectReference: {fileID: 0}
     - target: {fileID: 8389002920890670442, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_Controller
@@ -8922,6 +8958,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: attackTrigger
+      value: Attack
+      objectReference: {fileID: 0}
     - target: {fileID: 8389002920890670442, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_Controller
       value: 
@@ -9174,6 +9214,14 @@ PrefabInstance:
     - target: {fileID: 1547413830857976226, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: dropsScrolls
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5442366955441259943, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
+      propertyPath: attackTrigger
+      value: Attack
       objectReference: {fileID: 0}
     - target: {fileID: 8389002920890670442, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
       propertyPath: m_Controller
@@ -9496,7 +9544,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 817507512405637683}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 305.44, y: -5.2, z: 0}
+  m_LocalPosition: {x: 308.13, y: -5.2, z: 0}
   m_LocalScale: {x: 3, y: 3, z: 3}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -9680,10 +9728,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8389002920890670442, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: 3b7fcc074bf70fb4f899944839cdb2ad, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ff60b42d34c683144a089d9ea68d7602, type: 3}
 --- !u!1 &2815917237813520515 stripped
@@ -9850,9 +9894,25 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 215877687, guid: 3de92ed405112454787ed3da28a4c50b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 337.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 215877687, guid: 3de92ed405112454787ed3da28a4c50b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.68
+      objectReference: {fileID: 0}
     - target: {fileID: 478216404, guid: 3de92ed405112454787ed3da28a4c50b, type: 3}
       propertyPath: m_LocalPosition.y
       value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465243932, guid: 3de92ed405112454787ed3da28a4c50b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 321.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 1605919219, guid: 3de92ed405112454787ed3da28a4c50b, type: 3}
+      propertyPath: m_Size.x
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1605919222, guid: 3de92ed405112454787ed3da28a4c50b, type: 3}
       propertyPath: lever
@@ -9878,6 +9938,10 @@ PrefabInstance:
       propertyPath: boundaries.Array.data[1]
       value: 
       objectReference: {fileID: 1342085816}
+    - target: {fileID: 4046784162128405472, guid: 3de92ed405112454787ed3da28a4c50b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 356.88
+      objectReference: {fileID: 0}
     - target: {fileID: 4798801261946796659, guid: 3de92ed405112454787ed3da28a4c50b, type: 3}
       propertyPath: m_RootOrder
       value: 0

--- a/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/SceneTransitionPoint2D.cs
+++ b/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/SceneTransitionPoint2D.cs
@@ -20,6 +20,8 @@ public class SceneTransitionPoint2D : SceneTransitionPoint
             if (countAsLevelComplete) gameManager.gameData.UpdateLevelComplete(completedChapter, completedLevel);
 
             localGameManager.SceneTransition(sceneToTransition, spawnpointNameOverride);
+            gameManager.Popup("Press E to Enter", false);
+            canTransition = false;
         }
     }
 

--- a/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/SceneTransitionPoint3D.cs
+++ b/Mythology Mayhem/Assets/Travis_TestingFolder_WillOrganizeAfterTesting/TestScripts/SceneTransitionPoint3D.cs
@@ -30,6 +30,7 @@ public class SceneTransitionPoint3D : SceneTransitionPoint
 
             // transition to the next scene/level
             localGameManager.SceneTransition(sceneToTransition, spawnpointNameOverride);
+            gameManager.Popup("Press E to Enter", false);
             canTransition = false;
         }
     }


### PR DESCRIPTION
Fixed a bug where the 2D mice would not drop the scrolls. Fixed a warning message regarding the 2D mice.
Adjusted spacing of the 2D library's pedestal, door and lever. This fixes a bug where the doors interact UI would not appear in some instances. Fixed a bug where the enter UI would not disappear after entering a 2D or 3D door.