### PR TITLE
2D Bow Attack

### DIFF
--- a/Mythology Mayhem/Assets/2D Assets/Global/Items/Arrows/arrow.png
+++ b/Mythology Mayhem/Assets/2D Assets/Global/Items/Arrows/arrow.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2f1ba4aafa5ead5ab39f94cfc52dffd987cd27840815fb28cb820c4b26ddd2e4
-size 16227
+oid sha256:3b0c3d2b975e67e9023a6ebc43584ed8f0d7f89bbe712a3b971440a4b68cd232
+size 5842

--- a/Mythology Mayhem/Assets/2D Assets/Global/Items/Arrows/arrow.png.meta
+++ b/Mythology Mayhem/Assets/2D Assets/Global/Items/Arrows/arrow.png.meta
@@ -67,7 +67,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 256
+    maxTextureSize: 512
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 3
@@ -95,6 +95,18 @@ TextureImporter:
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 256
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 3
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/Arrow2D.cs
+++ b/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/Arrow2D.cs
@@ -5,24 +5,15 @@ using UnityEngine;
 public class Arrow2D : MonoBehaviour
 {
     public int damage;
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
+
     void OnCollisionEnter2D(Collision2D col)
     {
-        if(col.collider.tag == "Enemy")
+        if (col.collider.tag == "Player") return;
+        if (col.collider.tag == "Enemy")
         {
             if (col.gameObject.GetComponent<Health>())
                 col.gameObject.GetComponent<Health>().TakeDamage(damage);
         }
         Destroy(gameObject);
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
     }
 }

--- a/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/PlayerStats.cs
+++ b/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/PlayerStats.cs
@@ -112,6 +112,7 @@ public class PlayerStats : MonoBehaviour
     private void Attack()
     {
         if (anim.GetBool("IsDead")) return;
+        anim.SetBool("UseSword", true);
         anim.SetTrigger("Attack");
         swordAttackAS.Play();
         Collider2D[] hitEnemies = Physics2D.OverlapCapsuleAll(attackPoint.position, new Vector2(ps.AttackRange, ps.AttackRange+ps.AttackHeight), CapsuleDirection2D.Vertical, 0f, enemyLayers);

--- a/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/Shoot2D.cs
+++ b/Mythology Mayhem/Assets/2D Assets/Global/Scripts/2D/Shoot2D.cs
@@ -5,161 +5,116 @@ using UnityEngine.SceneManagement;
 
 public class Shoot2D : MonoBehaviour
 {
+    GameManager gameManager;
+    PlayerController playerController;
+    PlayerStats playerStats;
+    Animator anim;
+
+    public PlayerStats_SO ps;
+    public AudioSource audioSource;
     public GameObject ArrowPrefab;
     public Transform ArrowSpawn;
-    public float TBS = 0f;
+
     private float m_timestamp = 0f;
-    public AudioSource source;
     public float AS = 0f;
     public float AL = 0f;
     public float AL2 = 0f;
-    public GameObject player;
-    private bool CS = false;
-    private float up = 0f;
-    private bool CSU = false;
-    private bool CSN = false;
+    private bool canShoot = false;
+    private float aim = 0f;
+    private bool canShootUp = false;
+    private bool canShootDown = false;
+    private bool canShootAhead = false;
     [SerializeField] private float ASx = 0f;
     [SerializeField] private float ASy = 0f;
     [SerializeField] private float AD = 0f;
     [SerializeField] private float ADi = 0f;
-    private bool CSD = false;
 
-    [SerializeField] private Animator anim;
-    [SerializeField] public PlayerStats_SO ps;
 
-    void Start()
+    private void Awake()
     {
-        CS = false;
-
-        HealthUIController huic = GameObject.FindGameObjectWithTag("huic").GetComponent<HealthUIController>();
-        if(huic != null) { 
-            ps = huic.ps;
-            ps.CanAttack = true;
-            ps.NextAttackTime = 0;
-            //ps.CurrHealth = ps.MaxHealth;
-        }
-        else{
-            print("Can't find huic's player stats so");
-        }
+        playerController = GetComponent<PlayerController>();
+        playerStats = GetComponent<PlayerStats>();
+        anim = GetComponent<Animator>();
+        gameManager = GameManager.instance;
     }
     void Update()
     {
-        up = Input.GetAxisRaw("Vertical");
-        if (Input.GetKeyDown(KeyCode.X) && CS == true || Input.GetKeyDown(KeyCode.X) && CS == false)
-        {
-            CS = !CS;
-        }
-        if (CS == true)
-        {
-            anim.SetBool("CanShoot", true);
-            anim.SetBool("UseSword", false);
+        if (playerController.pushing) return;
+        if (playerController.climbing) return;
+        if (!gameManager.gameData.collectedBow) return;
+        if (Time.timeScale != 1) return;
 
-            ps.CanAttack = false;
-        }
-        if (CS == false)
+        if (Input.GetKeyDown(KeyCode.Alpha1))
         {
-            anim.SetBool("CanShoot", false);
-            anim.SetBool("UseSword", true);
+            canShoot = !canShoot;
 
-            ps.CanAttack = true;
+            anim.SetBool("CanShoot", canShoot);
+            anim.SetBool("UseSword", !canShoot);
+
+            ps.CanAttack = !canShoot;
         }
-        /*if(SceneManager.GetActiveScene().name == "2Dlabyrinth_Levers 1" || SceneManager.GetActiveScene().name == "2Dlabyrinth_Pedastals")
-        {
-            CS = false;
-        }*/
-        if ((Time.time >= m_timestamp) && (Input.GetKeyDown(KeyCode.Mouse0)) && player.GetComponent<PlayerController>().pushing == false && CS == true && CSN == true)
+
+        if (!canShoot) return;
+
+        aim = Input.GetAxisRaw("Vertical");
+
+        canShootUp = aim > 0;
+        canShootDown = aim < 0;
+        canShootAhead = aim == 0;
+
+        anim.SetBool("CanShootUpward", canShootUp);
+        anim.SetBool("CanShootDownward", canShootDown);
+
+        if (Time.time >= m_timestamp && Input.GetKeyDown(KeyCode.Mouse0))
         {
             Shoot();
-            m_timestamp = Time.time + TBS;
-            source.Play();
-        }
-        if (up == 1f)
-        {
-            CSU = true;
-            CSD = false;
-            anim.SetBool("CanShootUpward", true);
-        }
-        else if (up == 0f)
-        {
-            CSU = false;
-            CSD = false;
-            anim.SetBool("CanShootUpward", false);
-            anim.SetBool("CanShootDownward", false);
-        }
-        if(up == -1f)
-        {
-            CSD = true;
-            CSU = false;
-            anim.SetBool("CanShootDownward", true);
-        }
-        if (CSU == true || CSD == true)
-        {
-            CSN = false;
-        }
-        else if (CSU == false || CSD == false)
-        {
-            CSN = true;
-        }
-        if ((Time.time >= m_timestamp) && (Input.GetKeyDown(KeyCode.Mouse0)) && player.GetComponent<PlayerController>().pushing == false && CS == true && CSU == true && CSN == false && CSD == false)
-        {
-            ShootUp();
-            m_timestamp = Time.time + TBS;
-            source.Play();
-        }
-        if ((Time.time >= m_timestamp) && (Input.GetKeyDown(KeyCode.Mouse0)) && player.GetComponent<PlayerController>().pushing == false && CS == true && CSD == true)
-        {
-            ShootDown();
-            m_timestamp = Time.time + TBS;
-            source.Play();
+            m_timestamp += Time.deltaTime;
+            audioSource.Play();
         }
     }
 
     public void Shoot()
     {
-        anim.SetTrigger("Shoot");
-        if (gameObject.GetComponent<PlayerStats>().flipped == false)
+        GameObject arrow = Instantiate(ArrowPrefab, ArrowSpawn.position, ArrowSpawn.rotation);
+        Rigidbody2D rb = arrow.GetComponent<Rigidbody2D>();
+
+        if (aim == 0)
         {
-            var arrow = (GameObject)Instantiate(ArrowPrefab, ArrowSpawn.position, ArrowSpawn.rotation);
-            arrow.GetComponent<Rigidbody2D>().velocity = new Vector2(AS, 0.0f);
+            anim.SetTrigger("Shoot");
             Destroy(arrow, AL);
+
+            if (playerStats.flipped)
+            {
+                arrow.transform.rotation = Quaternion.Euler(0, 180, 0);
+                rb.velocity = new Vector2(-AS, 0.0f);
+            }
+            else rb.velocity = new Vector2(AS, 0.0f);
         }
-        else
+        else if (aim > 0)
         {
-            var arrow = (GameObject)Instantiate(ArrowPrefab, ArrowSpawn.position, Quaternion.Euler(0, 180, 0));
-            arrow.GetComponent<Rigidbody2D>().velocity = new Vector2(-AS, 0.0f);
-            Destroy(arrow, AL);
+            anim.SetTrigger("ShootUpward");
+            arrow.transform.rotation = Quaternion.Euler(0, 0, AD);
+            Destroy(arrow, AL2);
+
+            if (playerStats.flipped)
+            {
+                arrow.transform.rotation = Quaternion.Euler(0, 180, AD);
+                rb.velocity = new Vector2(-ASx, ASy);
+            }
+            else rb.velocity = new Vector2(ASx, ASy);
         }
-    }
-    public void ShootUp()
-    {
-        anim.SetTrigger("ShootUpward");
-        if (up > 0.01f && CSU == true && gameObject.GetComponent<PlayerStats>().flipped == false && CSD == false)
+        else if (aim < 0)
         {
-            var arrow2 = (GameObject)Instantiate(ArrowPrefab, ArrowSpawn.position, Quaternion.Euler(0, 0, AD));
-            arrow2.GetComponent<Rigidbody2D>().velocity = new Vector2(ASx, ASy);
-            Destroy(arrow2, AL2);
-        }
-        if (up > 0.01f && CSU == true && gameObject.GetComponent<PlayerStats>().flipped == true && CSD == false)
-        {
-            var arrow2 = (GameObject)Instantiate(ArrowPrefab, ArrowSpawn.position, Quaternion.Euler(0, 180, AD));
-            arrow2.GetComponent<Rigidbody2D>().velocity = new Vector2(-ASx, ASy);
-            Destroy(arrow2, AL2);
-        }
-    }
-    public void ShootDown()
-    {
-        anim.SetTrigger("ShootDownward");
-        if (up < 0f && CSU == false && gameObject.GetComponent<PlayerStats>().flipped == false && CSD == true)
-        {
-            var arrow3 = (GameObject)Instantiate(ArrowPrefab, ArrowSpawn.position, Quaternion.Euler(0, 0, ADi));
-            arrow3.GetComponent<Rigidbody2D>().velocity = new Vector2(ASx, -ASy);
-            Destroy(arrow3, AL2);
-        }
-        if (up < 0f && CSU == false && gameObject.GetComponent<PlayerStats>().flipped == true && CSD == true)
-        {
-            var arrow3 = (GameObject)Instantiate(ArrowPrefab, ArrowSpawn.position, Quaternion.Euler(0, 180, ADi));
-            arrow3.GetComponent<Rigidbody2D>().velocity = new Vector2(-ASx, -ASy);
-            Destroy(arrow3, AL2);
+            anim.SetTrigger("ShootDownward");
+            arrow.transform.rotation = Quaternion.Euler(0, 0, ADi);
+            Destroy(arrow, AL2);
+
+            if (playerStats.flipped)
+            {
+                arrow.transform.rotation = Quaternion.Euler(0, 180, ADi);
+                rb.velocity = new Vector2(-ASx, -ASy);
+            }
+            else rb.velocity = new Vector2(ASx, -ASy);
         }
     }
 }

--- a/Mythology Mayhem/Assets/2D Assets/Greek/Enemies2D/Bird/Bird_Prefab.prefab
+++ b/Mythology Mayhem/Assets/2D Assets/Greek/Enemies2D/Bird/Bird_Prefab.prefab
@@ -124,10 +124,10 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -1.9271894, y: -0.88337755}
+  m_Offset: {x: 0, y: -0.22850439}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -138,7 +138,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 7.5900393, y: 4.238112}
+  m_Size: {x: 4, y: 1.8829913}
   m_EdgeRadius: 0
 --- !u!114 &5518047496158701024
 MonoBehaviour:
@@ -181,6 +181,8 @@ MonoBehaviour:
   patrolDistance: 2
   speed: 1.2
   patrolBool: IsPatrolling
+  isFlying: 0
+  attackTriggers: []
   attackTrigger: Attack
   meleeDistance: 4
   waypoints:
@@ -422,6 +424,7 @@ MonoBehaviour:
   respawnTimer: 50
   canRespawn: 0
   loadSystem: {fileID: 0}
+  isDead: 0
 --- !u!1 &6941042193202341063
 GameObject:
   m_ObjectHideFlags: 0

--- a/Mythology Mayhem/Assets/2D Assets/Greek/GreekBoy/GreekBoy/GreekBoy.prefab
+++ b/Mythology Mayhem/Assets/2D Assets/Greek/GreekBoy/GreekBoy/GreekBoy.prefab
@@ -373,20 +373,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0e238e4a0c821bf4e861b3bea4acb057, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ps: {fileID: 11400000, guid: 3ce03f4a16bd351458bc7c47b3a5ebf1, type: 2}
+  audioSource: {fileID: 5723941419285221517}
   ArrowPrefab: {fileID: 5372321048262100931, guid: 8fbb30cfbe27c3a4281e2376859cfcd9, type: 3}
   ArrowSpawn: {fileID: 8594565072132099985}
-  TBS: 1
-  source: {fileID: 5723941419285221517}
   AS: 50
   AL: 1
   AL2: 2
-  player: {fileID: 537872656705047756}
   ASx: 50
-  ASy: 6.25
+  ASy: 10
   AD: 12.5
-  ADi: 347.5
-  anim: {fileID: 537872656705047759}
-  ps: {fileID: 11400000, guid: 3ce03f4a16bd351458bc7c47b3a5ebf1, type: 2}
+  ADi: 350
 --- !u!114 &1090590915072749807
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -689,6 +686,7 @@ MonoBehaviour:
   camera2D: {fileID: 537872657209584497}
   target: {fileID: 537872656705047756}
   buffer: 0
+  height: 0
 --- !u!1 &2311921730407220284
 GameObject:
   m_ObjectHideFlags: 0

--- a/Mythology Mayhem/Assets/2D Assets/Greek/GreekBoy/GreekController.controller
+++ b/Mythology Mayhem/Assets/2D Assets/Greek/GreekBoy/GreekController.controller
@@ -248,19 +248,6 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!114 &-6661284219913690667
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0b70d8b3600c42649b90a9e277443883, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  BowArrow: {fileID: 11400000, guid: 22408611db1fd3042a1e189c26714c5b, type: 2}
 --- !u!1101 &-6504684362224614446
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1376,8 +1363,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 1156975917782844475}
-  m_StateMachineBehaviours:
-  - {fileID: -6661284219913690667}
+  m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1

--- a/Mythology Mayhem/Assets/Global Assets/Prefabs/TempPrefabs/ArrowAnalog2D.prefab
+++ b/Mythology Mayhem/Assets/Global Assets/Prefabs/TempPrefabs/ArrowAnalog2D.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 2038042678679434001}
   - component: {fileID: 6677427397951871571}
   - component: {fileID: 94115612605865074}
-  - component: {fileID: 6483095305880646699}
+  - component: {fileID: 8060159149218640177}
   m_Layer: 0
   m_Name: ArrowAnalog2D
   m_TagString: Untagged
@@ -28,8 +28,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5372321048262100931}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.5, y: -1.25, z: 0}
-  m_LocalScale: {x: 1, y: -1, z: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -77,7 +77,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 100
   m_Sprite: {fileID: 21300000, guid: 8d577df5cca5c5a4d88c30bb8ac7dd4d, type: 3}
-  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -121,8 +121,8 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!58 &6483095305880646699
-CircleCollider2D:
+--- !u!61 &8060159149218640177
+BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -135,5 +135,15 @@ CircleCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2.82, y: 0.59}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
   serializedVersion: 2
-  m_Radius: 0.5
+  m_Size: {x: 2.84, y: 0.61015624}
+  m_EdgeRadius: 0


### PR DESCRIPTION
Simplified the Shoot2D script.
The 2D bow is now activated by pressing 1.
The 2D bow will not work if the game is paused, the player has not collected the bow or of the player is pushing or climbing. Cleaned up the 2D arrow .png.
Fixed the 2D arrow box collider.
The 2D arrow will no longer collide with the player. Fixed a bug that prevented the sword animation from playing after switching to the bow and back to the sword. Fixed a bug with the 2D bird collider.